### PR TITLE
Fix CDAT Data Read Error during System Boot

### DIFF
--- a/opencxl/cxl/config_space/doe/doe_table_access.py
+++ b/opencxl/cxl/config_space/doe/doe_table_access.py
@@ -97,8 +97,11 @@ class DoeTableAccessProtocol(DoeMailboxProtocolBase):
 
         # TODO: Calculate checksum
         cdat_header = CdatHeader()
+        cdat_header.length = len(cdat_header)
         self._entries.append(cdat_header)
         for entry in entries:
+            logger.debug(f"[DOE] Adding an entry, type: {type(entry)}")
+            cdat_header.length += entry.length
             self._entries.append(entry)
 
     def process_request(self, mailbox_context: DoeMailboxContext) -> bool:

--- a/opencxl/cxl/config_space/doe/doe_table_access.py
+++ b/opencxl/cxl/config_space/doe/doe_table_access.py
@@ -100,7 +100,6 @@ class DoeTableAccessProtocol(DoeMailboxProtocolBase):
         cdat_header.length = len(cdat_header)
         self._entries.append(cdat_header)
         for entry in entries:
-            logger.debug(f"[DOE] Adding an entry, type: {type(entry)}")
             cdat_header.length += entry.length
             self._entries.append(entry)
 

--- a/opencxl/pci/component/doe_mailbox.py
+++ b/opencxl/pci/component/doe_mailbox.py
@@ -188,7 +188,7 @@ class DoeMailboxComponent:
             return
 
         logger.debug(
-            "[DOE] Invalid protocol: Vendor ID = 0x%04x, Data Object Type = 0x%02x",
+            "[DOE] Valid protocol: Vendor ID = 0x%04x, Data Object Type = 0x%02x",
             vendor_id,
             data_object_type,
         )


### PR DESCRIPTION
The system bootup process will complain about CDAT data read error like this:
```
[eeum@localhost ~]$ dmesg | grep CDAT
[   11.037075] cxl_port endpoint3: CDAT data read error
[   11.189869] cxl_port endpoint4: CDAT data read error
[   11.334996] cxl_port endpoint5: CDAT data read error
[   11.482844] cxl_port endpoint6: CDAT data read error
```

The problem is caused by the uninitialized CDAT header size field. This commit fixes the issue by initializing the field.